### PR TITLE
Update mqtt.go

### DIFF
--- a/mqtt.go
+++ b/mqtt.go
@@ -147,7 +147,7 @@ func (client *MQTTClient) Run() {
 		}
 	}
 
-	client.Publish("parasite-scanner/status", "online", false, 1) //publish online status
+	client.Publish("parasite-scanner/status", "online", false, 1)
 
 	for data := range client.outgoing {
 		deviceConfig, exists := client.config.Registry[MACAddr(data.Key)]

--- a/mqtt.go
+++ b/mqtt.go
@@ -147,7 +147,7 @@ func (client *MQTTClient) Run() {
 		}
 	}
 
-	client.Publish("parasite-scanner/status", "online", false, 1)
+	client.Publish("parasite-scanner/status", "online", true, 1)
 
 	for data := range client.outgoing {
 		deviceConfig, exists := client.config.Registry[MACAddr(data.Key)]

--- a/mqtt.go
+++ b/mqtt.go
@@ -147,7 +147,7 @@ func (client *MQTTClient) Run() {
 		}
 	}
 
-	client.Publish("parasite-scanner/status", "online", false, 1)//publish online status
+	client.Publish("parasite-scanner/status", "online", false, 1) //publish online status
 
 	for data := range client.outgoing {
 		deviceConfig, exists := client.config.Registry[MACAddr(data.Key)]

--- a/mqtt.go
+++ b/mqtt.go
@@ -147,7 +147,7 @@ func (client *MQTTClient) Run() {
 		}
 	}
 
-	client.Publish(fmt.Sprintf("parasite-scanner/status"), fmt.Sprintf("online"), false, 1)//publish online status
+	client.Publish("parasite-scanner/status", "online", false, 1)//publish online status
 
 	for data := range client.outgoing {
 		deviceConfig, exists := client.config.Registry[MACAddr(data.Key)]

--- a/mqtt.go
+++ b/mqtt.go
@@ -21,7 +21,8 @@ func MakeMQTTClient(cfg *MQTTConfig) *MQTTClient {
 		AddBroker(cfg.Host).
 		SetUsername(cfg.Username).
 		SetPassword(cfg.Password).
-		SetClientID(cfg.ClientId)
+		SetClientID(cfg.ClientId).
+		SetWill("parasite-scanner/status", "offline", 1, false)
 
 	// opts.SetKeepAlive(1 * time.Second)
 	// opts.SetPingTimeout(1 * time.Second)

--- a/mqtt.go
+++ b/mqtt.go
@@ -147,6 +147,8 @@ func (client *MQTTClient) Run() {
 		}
 	}
 
+	client.Publish(fmt.Sprintf("parasite-scanner/status"), fmt.Sprintf("online"), false, 1)//publish online status
+
 	for data := range client.outgoing {
 		deviceConfig, exists := client.config.Registry[MACAddr(data.Key)]
 		if !exists {


### PR DESCRIPTION
In Home Assistant sensor values were not be displayed automatically, even though the payload was submitted: 
![Bildschirmfoto 2021-05-25 um 18 06 13](https://user-images.githubusercontent.com/6669125/119533291-fb56c580-bd85-11eb-9e39-cc634798090f.png)

This change publishes an online status for the whole system and allows home assistant to automatically pick up the values.

